### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ Dev:
 
 Changelog
 ----
-####v0.2.1
+#### v0.2.1
 * Added filler template pages, including user settings page
 * Reorganized module naming (`mod_home`->`mod_unauthenticated`)
 * Restyled Bootstrap in homepage and navbar
 
-####v0.2.0
+#### v0.2.0
 * Flask Blueprints
 * Flask-assets asset for Javascript and other static assets, based on the webassets module
 * CSRF protection


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
